### PR TITLE
Metrics update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.mcstats.bukkit</groupId>
             <artifactId>metrics</artifactId>
-            <version>R7</version>
+            <version>R8-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Fixed:
```
org.apache.commons.lang.UnhandledException: Plugin ChestShop v3.8.13 generated an exception while executing task 1545
        at org.bukkit.craftbukkit.v1_10_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:56)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NoSuchMethodError: org.bukkit.Server.getOnlinePlayers()[Lorg/bukkit/entity/Player;
        at com.Acrobot.ChestShop.Metrics.postPlugin(Metrics.java:335)
        at com.Acrobot.ChestShop.Metrics.access$400(Metrics.java:57)
        at com.Acrobot.ChestShop.Metrics$1.run(Metrics.java:223)
        at org.bukkit.craftbukkit.v1_10_R1.scheduler.CraftTask.run(CraftTask.java:71)
        at org.bukkit.craftbukkit.v1_10_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53)
        ... 3 more
```